### PR TITLE
Fix broken links

### DIFF
--- a/docs/chapter4/token-2022.md
+++ b/docs/chapter4/token-2022.md
@@ -12,7 +12,7 @@ The Token-2022 program extends the functionality provided by the [Token program]
 
 !!! tip
 
-    To see the source code, check out [Solana Program Library Token-2022 program](https://github.com/solana-labs/solana-program-library/tree/master/token/program-2022).
+    To see the source code, check out [Solana Program Library Token-2022 program](https://github.com/solana-program/token-2022/tree/main/program).
 
 <h2>Benefits</h2>
 

--- a/docs/chapter4/token-program.md
+++ b/docs/chapter4/token-program.md
@@ -15,7 +15,7 @@ Token program defines a common implementation for fungible and non-fungible toke
 
 !!! tip
 
-    To see the source code, check out [Solana Program Library Token program](https://github.com/solana-labs/solana-program-library/tree/master/token/program).
+    To see the source code, check out [Solana Program Library Token program](https://github.com/solana-program/token/tree/main/program).
 
 
 !!! info


### PR DESCRIPTION
Update the reference links for the Token and Token-2022 programs.

According to the [solana-program-library/token](https://github.com/solana-labs/solana-program-library/tree/master/token), the Token and Token-2022 programs are now maintained at [solana-program](https://github.com/solana-program).